### PR TITLE
[CARGS] Use long for base, kernel_offset, ramdisk_offset, second_offset and tags_offset

### DIFF
--- a/abootimg/src/main/groovy/cfig/bootimg/CArgs.groovy
+++ b/abootimg/src/main/groovy/cfig/bootimg/CArgs.groovy
@@ -17,12 +17,12 @@ class CArgs {
     public String cmdline;
     public String os_version;
     public String os_patch_level;
-    public int base;
-    public int kernel_offset;
-    public int ramdisk_offset;
-    public int second_offset;
+    public long base;
+    public long kernel_offset;
+    public long ramdisk_offset;
+    public long second_offset;
     public int pagesize;
-    public int tags_offset;
+    public long tags_offset;
     public boolean id;
 
     public CArgs() {
@@ -36,23 +36,23 @@ class CArgs {
     public List<String> toCommandList() {
         List<String> ret = new ArrayList<String>();
         ret.add("--base");
-        ret.add("0x" + Integer.toHexString(base));
+        ret.add("0x" + Long.toHexString(base));
         ret.add("--kernel");
         ret.add(kernel);
         ret.add("--kernel_offset");
-        ret.add("0x" + Integer.toHexString(kernel_offset));
+        ret.add("0x" + Long.toHexString(kernel_offset));
         if (null != ramdisk) {
             ret.add("--ramdisk");
             ret.add(ramdisk);
         }
         ret.add("--ramdisk_offset");
-        ret.add("0x" + Integer.toHexString(ramdisk_offset));
+        ret.add("0x" + Long.toHexString(ramdisk_offset));
         if (null != second) {
             ret.add("--second");
             ret.add(second);
         }
         ret.add("--second_offset");
-        ret.add("0x" + Integer.toHexString(second_offset));
+        ret.add("0x" + Long.toHexString(second_offset));
         if (null != board) {
             ret.add("--board");
             ret.add(board);
@@ -70,7 +70,7 @@ class CArgs {
             ret.add(os_patch_level);
         }
         ret.add("--tags_offset");
-        ret.add("0x" + Integer.toHexString(tags_offset));
+        ret.add("0x" + Long.toHexString(tags_offset));
         if (id) {
             ret.add("--id");
         }

--- a/abootimg/src/main/groovy/cfig/bootimg/CImgInfo.groovy
+++ b/abootimg/src/main/groovy/cfig/bootimg/CImgInfo.groovy
@@ -32,11 +32,11 @@ class CImgInfo  extends CArgs {
         //arg info
         aArg.board = result.bootimg.args.board;
         aArg.cmdline = result.bootimg.args.cmdline;
-        aArg.base = Integer.decode(result.bootimg.args.base);
-        aArg.kernel_offset = Integer.decode(result.bootimg.args.kernel_offset);
-        aArg.ramdisk_offset = Integer.decode(result.bootimg.args.ramdisk_offset);
-        aArg.second_offset = Integer.decode(result.bootimg.args.second_offset);
-        aArg.tags_offset = Integer.decode(result.bootimg.args.tags_offset);
+        aArg.base = Long.decode(result.bootimg.args.base);
+        aArg.kernel_offset = Long.decode(result.bootimg.args.kernel_offset);
+        aArg.ramdisk_offset = Long.decode(result.bootimg.args.ramdisk_offset);
+        aArg.second_offset = Long.decode(result.bootimg.args.second_offset);
+        aArg.tags_offset = Long.decode(result.bootimg.args.tags_offset);
         aArg.id = true;
         aArg.pagesize = result.bootimg.args.pagesize;
         aArg.os_version = result.bootimg.args.os_version;
@@ -69,11 +69,11 @@ class CImgInfo  extends CArgs {
         String hashString = bytes2String(this.hash);
         jb.bootimg {
             args {
-                base "0x" + Integer.toHexString(this.base);
-                kernel_offset "0x" + Integer.toHexString(this.kernel_offset);
-                ramdisk_offset "0x" + Integer.toHexString(this.ramdisk_offset);
-                second_offset "0x" + Integer.toHexString(this.second_offset);
-                tags_offset "0x" + Integer.toHexString(this.tags_offset);
+                base "0x" + Integer.toHexString((int)this.base);
+                kernel_offset "0x" + Integer.toHexString((int)this.kernel_offset);
+                ramdisk_offset "0x" + Integer.toHexString((int)this.ramdisk_offset);
+                second_offset "0x" + Integer.toHexString((int)this.second_offset);
+                tags_offset "0x" + Integer.toHexString((int)this.tags_offset);
                 pagesize this.pagesize;
                 board this.board;
                 cmdline this.cmdline;

--- a/abootimg/src/main/groovy/cfig/bootimg/Packer.groovy
+++ b/abootimg/src/main/groovy/cfig/bootimg/Packer.groovy
@@ -52,19 +52,19 @@ class Packer {
         ret.id = options.has("id")
 
         if (options.has("base")) {
-            ret.base = Integer.decode(String.valueOf(options.valueOf("base")))
+            ret.base = Long.decode(String.valueOf(options.valueOf("base")))
         } else {
             ret.base = 0x10000000;
         }
 
         if (options.has("kernel_offset")) {
-            ret.kernel_offset = Integer.decode(String.valueOf(options.valueOf("kernel_offset")))
+            ret.kernel_offset = Long.decode(String.valueOf(options.valueOf("kernel_offset")))
         } else {
             ret.kernel_offset = 0x00008000;
         }
 
         if (options.has("ramdisk_offset")) {
-            ret.ramdisk_offset = Integer.decode(String.valueOf(options.valueOf("ramdisk_offset")))
+            ret.ramdisk_offset = Long.decode(String.valueOf(options.valueOf("ramdisk_offset")))
         } else {
             ret.ramdisk_offset = 0x01000000
         }
@@ -74,13 +74,13 @@ class Packer {
         ret.os_patch_level = options.valueOf("os_patch_level")
 
         if (options.has("second_offset")) {
-            ret.second_offset = Integer.decode(String.valueOf(options.valueOf("second_offset")))
+            ret.second_offset = Long.decode(String.valueOf(options.valueOf("second_offset")))
         } else {
             ret.second_offset = 0x00f00000
         }
 
         if (options.has("tags_offset")) {
-            ret.tags_offset = Integer.decode(String.valueOf(options.valueOf("tags_offset")))
+            ret.tags_offset = Long.decode(String.valueOf(options.valueOf("tags_offset")))
         } else {
             ret.tags_offset = 0x00000100
         }
@@ -124,7 +124,7 @@ class Packer {
         //header start
         bf.put("ANDROID!".getBytes())
         bf.putInt((int) new File(inArgs.kernel).length());
-        bf.putInt(inArgs.base + inArgs.kernel_offset)
+        bf.putInt((int)(inArgs.base + inArgs.kernel_offset));
 
         if (null == inArgs.ramdisk) {
             bf.putInt(0)
@@ -132,7 +132,7 @@ class Packer {
             bf.putInt((int) new File(inArgs.ramdisk).length());
         }
 
-        bf.putInt(inArgs.base + inArgs.ramdisk_offset)
+        bf.putInt((int)(inArgs.base + inArgs.ramdisk_offset));
 
         if (null == inArgs.second) {
             bf.putInt(0)
@@ -140,8 +140,8 @@ class Packer {
             bf.putInt((int) new File(inArgs.second).length());
         }
 
-        bf.putInt(inArgs.base + inArgs.second_offset)
-        bf.putInt(inArgs.base + inArgs.tags_offset)
+        bf.putInt((int)(inArgs.base + inArgs.second_offset));
+        bf.putInt((int)(inArgs.base + inArgs.tags_offset));
         bf.putInt(inArgs.pagesize)
         bf.putInt(0);
         bf.putInt((parse_os_version(inArgs.os_version) << 11) | parse_os_patch_level(inArgs.os_patch_level))


### PR DESCRIPTION
Fixes https://github.com/cfig/Android_boot_image_editor/issues/13 partially
Does not fix base address calculation, but fixes repacking of affected images