### PR TITLE
do strict checking before extracting 'args.base'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 bouncycastle/* linguist-vendored
 boot_signer/*  linguist-vendored
 mkbootfs/*     linguist-vendored
+avb/*          linguist-vendored

--- a/bbootimg/src/main/kotlin/Parser.kt
+++ b/bbootimg/src/main/kotlin/Parser.kt
@@ -123,7 +123,10 @@ class Parser {
             info.recoveryDtboPosition = info.secondBootloaderPosition + info.secondBootloaderLength + getPaddingSize(info.secondBootloaderLength, args.pageSize)
 
             //adjust args
-            if (args.kernelOffset > Int.MAX_VALUE) {
+            if (args.kernelOffset > Int.MAX_VALUE
+                    && args.ramdiskOffset > Int.MAX_VALUE
+                    && args.secondOffset > Int.MAX_VALUE
+                    && args.dtboOffset > Int.MAX_VALUE) {
                 args.base = Int.MAX_VALUE + 1L
                 args.kernelOffset -= args.base
                 args.ramdiskOffset -= args.base


### PR DESCRIPTION
Fixes #18, 'unpack' and 'pack' works,
but seems Moto X image has private data fields, which can not be recognized