### PR TITLE
Lzma early than lz4.

### DIFF
--- a/bbootimg/src/main/kotlin/bootimg/Common.kt
+++ b/bbootimg/src/main/kotlin/bootimg/Common.kt
@@ -141,6 +141,15 @@ class Common {
                     ZipHelper.xzcat(s.dumpFile + ".xz", s.dumpFile)
                     ret = "xz"
                 }
+                ZipHelper.isLzma(s.dumpFile) -> {
+                    log.info("ramdisk is compressed lzma")
+                    Files.move(
+                            Paths.get(s.dumpFile), Paths.get(s.dumpFile + ".lzma"),
+                            java.nio.file.StandardCopyOption.REPLACE_EXISTING
+                    )
+                    ZipHelper.lzcat(s.dumpFile + ".lzma", s.dumpFile)
+                    ret = "lzma"
+                }
                 ZipHelper.isLz4(s.dumpFile) -> {
                     log.info("ramdisk is compressed lz4")
                     Files.move(
@@ -149,15 +158,6 @@ class Common {
                     )
                     ZipHelper.lz4cat(s.dumpFile + ".lz4", s.dumpFile)
                     ret = "lz4"
-                }
-                ZipHelper.isLzma(s.dumpFile) -> {
-                    log.info("ramdisk is compressed lzma")
-                    Files.move(
-                        Paths.get(s.dumpFile), Paths.get(s.dumpFile + ".lzma"),
-                        java.nio.file.StandardCopyOption.REPLACE_EXISTING
-                    )
-                    ZipHelper.lzcat(s.dumpFile + ".lzma", s.dumpFile)
-                    ret = "lzma"
                 }
                 else -> {
                     throw IllegalArgumentException("ramdisk is in unknown format")


### PR DESCRIPTION
* when user try to unpack image which ramdisk compressed with lzma, lz4 -t $IMAGE_FILE will return like 'Successfully decoded 13601602 bytes'. However in this case, tools cannot read entry and throw Exception.