### PR TITLE
Allow 'dangerous' symbolic links

### DIFF
--- a/bbootimg/src/main/kotlin/rom/sparse/SparseImage.kt
+++ b/bbootimg/src/main/kotlin/rom/sparse/SparseImage.kt
@@ -231,7 +231,7 @@ data class SparseImage(var info: SparseInfo = SparseInfo()) {
             if (EnvironmentVerifier().has7z) {
                 val stem = File(fileName).nameWithoutExtension
                 val outFilePath = Helper.joinPath(workDir, stem)
-                val outStr = "7z x $fileName -y -o$outFilePath".check_output()
+                val outStr = "7z -snld x $fileName -y -o$outFilePath".check_output()
                 File(workDir, "$stem.log").writeText(outStr)
             } else {
                 log.warn("Please install 7z for ext4 extraction")


### PR DESCRIPTION
ext4 extraction is failing because recent 7z does not allow symlinks pointing to paths above the archive root:

```
ERROR: Dangerous symbolic link path was ignored : system/framework/arm/boot-apache-xml.vdex : ../boot-apache-xml.vdex
ERROR: Dangerous symbolic link path was ignored : system/framework/arm/boot-apache-xml.vdex.fsv_meta : ../boot-apache-xml.vdex.fsv_meta
ERROR: Dangerous symbolic link path was ignored : system/framework/arm/boot-bouncycastle.vdex : ../boot-bouncycastle.vdex
```

This causes `./gradlew unpack` to fail with an error. Passing the `-snld` flag to 7z allows creation of those symlinks.